### PR TITLE
Refactor of notebook into individual scripts

### DIFF
--- a/JPF/import-hpd-buildings.py
+++ b/JPF/import-hpd-buildings.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import os.path
+import sys
+import logging
+
+
+from sqlalchemy import create_engine
+
+from utils import *
+
+mkdir_p(BASE_DIR)
+
+logging.basicConfig(format='[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s',
+    datefmt='%H:%M:%S',
+    stream=sys.stdout,
+    level=logging.INFO)
+log = logging.getLogger(__name__)
+
+"""
+HPD Buildings import
+"""
+
+HPD_BUILDINGS_KEY = 'hpd_buildings'
+
+bld_dtype_dict = {
+    'BuildingID':              'int64',
+    'BoroID':                  'int64',
+    'Boro':                   'object',
+    'HouseNumber':            'object',
+    'LowHouseNumber':         'object',
+    'HighHouseNumber':        'object',
+    'StreetName':             'object',
+    'Zip':                    'object',
+    'Block':                   'int64',
+    'Lot':                     'int64',
+    'BIN':                   'float64',
+    'CommunityBoard':          'int64',
+    'CensusTract':           'float64',
+    'ManagementProgram':      'object',
+    'DoBBuildingClassID':    'float64',
+    'DoBBuildingClass':       'object',
+    'LegalStories':          'float64',
+    'LegalClassA':           'float64',
+    'LegalClassB':           'float64',
+    'RegistrationID':          'int64',
+    'LifeCycle':              'object',
+    'RecordStatusID':          'int64',
+    'RecordStatus':           'object'
+}
+
+bld_df_keep_cols = [
+    'buildingid',
+    'boroid',
+    'boro',
+    'housenumber',
+    'lowhousenumber',
+    'highhousenumber',
+    'streetname',
+    'zip',
+    'block',
+    'lot',
+    'bin',
+    'communityboard',
+    'censustract',
+    'managementprogram',
+    'dobbuildingclassid',
+    'dobbuildingclass',
+    'legalstories',
+    'legalclassa',
+    'legalclassb',
+    'registrationid',
+    'lifecycle',
+    'recordstatusid',
+    'recordstatus'
+]
+
+def main(argv):
+
+    parser = argparse.ArgumentParser(description='Import hpd buildings dataset.')
+    parser = add_common_arguments(parser)
+    args = parser.parse_args()
+
+    print args
+
+    hpd_buildings_dir = os.path.join(BASE_DIR, HPD_BUILDINGS_KEY)
+    mkdir_p(hpd_buildings_dir)
+
+    hpd_buildings_csv = os.path.join(hpd_buildings_dir, "hpd_buildings.csv")
+
+    if not os.path.isfile(hpd_buildings_csv) or args.BUST_DISK_CACHE:
+        log.info("DL-ing HPD Buildings")
+        download_file("https://data.cityofnewyork.us/api/views/kj4p-ruqc/rows.csv?accessType=DOWNLOAD", hpd_buildings_csv)
+    else:
+        log.info("HPD Buildings exists, moving on...")
+
+    rcn_truncate_columns = ''
+    rcn_date_time_columns = ''
+
+    bld_description = "HPD Buildings"
+    bld_input_csv_url = hpd_buildings_csv
+    bld_sep_char = ","
+    bld_pickle = os.path.join(hpd_buildings_dir, 'df_buildings.pkl')
+    bld_table_name = 'hpd_buildings'
+    bld_load_pickle = args.LOAD_PICKLE
+    bld_save_pickle = args.SAVE_PICKLE
+    bld_db_action = 'replace' ## if not = 'replace' then 'append'
+    bld_truncate_columns = ''
+    bld_date_time_columns = ''
+    bld_chunk_size = 5000
+
+
+    hpd_csv2sql(
+                bld_description,
+                bld_input_csv_url,
+                bld_sep_char,
+                bld_table_name,
+                bld_dtype_dict,
+                bld_load_pickle,
+                bld_save_pickle,
+                bld_pickle,
+                bld_db_action,
+                bld_truncate_columns,
+                bld_date_time_columns,
+                bld_chunk_size,
+                bld_df_keep_cols
+               )
+
+if __name__ == "__main__":
+    main(sys.argv[:1])
+
+

--- a/JPF/import-hpd-registration-contact.py
+++ b/JPF/import-hpd-registration-contact.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import os.path
+import sys
+import logging
+
+
+from sqlalchemy import create_engine
+
+from utils import *
+
+mkdir_p(BASE_DIR)
+
+logging.basicConfig(format='[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s',
+    datefmt='%H:%M:%S',
+    stream=sys.stdout,
+    level=logging.INFO)
+log = logging.getLogger(__name__)
+
+"""
+HPD Registration import
+"""
+
+HPD_REGISTRATION_KEY = 'hpd_registration_contact'
+
+rcn_dtype_dict = {
+    'RegistrationContactID':     'int64',
+    'RegistrationID':            'int64',
+    'Type':                     'object',
+    'ContactDescription':       'object',
+    'CorporationName':          'object',
+    'Title':                    'object',
+    'FirstName':                'object',
+    'MiddleInitial':            'object',
+    'LastName':                 'object',
+    'BusinessHouseNumber':      'object',
+    'BusinessStreetName':       'object',
+    'BusinessApartment':        'object',
+    'BusinessCity':             'object',
+    'BusinessState':            'object',
+    'BusinessZip':              'object'
+}
+
+rcn_df_keep_cols = [
+    'registrationcontactid',
+    'registrationid',
+    'type',
+    'corporationname',
+    'contactdescription',
+    'title',
+    'firstname',
+    'middleinitial',
+    'lastname',
+    'businesshousenumber',
+    'businessstreetname',
+    'businessapartment',
+    'businesscity',
+    'businessstate',
+    'businesszip'
+]
+
+def main(argv):
+
+    parser = argparse.ArgumentParser(description='Import hpd registration dataset.')
+    parser = add_common_arguments(parser)
+    args = parser.parse_args()
+
+    print args
+
+    hpd_creg_dir = os.path.join(BASE_DIR, HPD_REGISTRATION_KEY)
+    mkdir_p(hpd_creg_dir)
+
+    hpd_reg_csv = os.path.join(hpd_creg_dir, "hpd_creg.csv")
+
+    if not os.path.isfile(hpd_reg_csv) or args.BUST_DISK_CACHE:
+        log.info("DL-ing HPD Registrations")
+        download_file("https://data.cityofnewyork.us/api/views/feu5-w2e2/rows.csv?accessType=DOWNLOAD", hpd_reg_csv)
+    else:
+        log.info("HPD Registrations exists, moving on...")
+
+    rcn_truncate_columns = ''
+    rcn_date_time_columns = ''
+
+    rcn_description = "HPD RegistrationsContacts"
+    rcn_input_csv_url = hpd_reg_csv
+    rcn_sep_char = ","
+    rcn_pickle = os.path.join(hpd_creg_dir, 'df_regCon.pkl')
+    rcn_table_name = 'hpd_registration_contacts'
+    rcn_load_pickle = args.LOAD_PICKLE
+    rcn_save_pickle = args.SAVE_PICKLE
+    rcn_db_action = 'replace' ## if not = 'replace' then 'append'
+    rcn_chunk_size = 5000
+
+    hpd_csv2sql(
+                rcn_description,
+                rcn_input_csv_url,
+                rcn_sep_char,
+                rcn_table_name,
+                rcn_dtype_dict,
+                rcn_load_pickle,
+                rcn_save_pickle,
+                rcn_pickle,
+                rcn_db_action,
+                rcn_truncate_columns,
+                rcn_date_time_columns,
+                rcn_chunk_size,
+                rcn_df_keep_cols
+            )
+
+if __name__ == "__main__":
+    main(sys.argv[:1])
+
+

--- a/JPF/import-hpd-registrations.py
+++ b/JPF/import-hpd-registrations.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import os.path
+import sys
+import logging
+
+
+from sqlalchemy import create_engine
+
+from utils import *
+
+mkdir_p(BASE_DIR)
+
+logging.basicConfig(format='[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s',
+    datefmt='%H:%M:%S',
+    stream=sys.stdout,
+    level=logging.INFO)
+log = logging.getLogger(__name__)
+
+"""
+HPD Registration import
+"""
+
+HPD_REGISTRATION_KEY = 'hpd_registration'
+
+reg_dtype_dict = {
+'RegistrationID':            'int64',
+'BuildingID':                'int64',
+'BoroID':                    'int64',
+'Boro':                     'object',
+'HouseNumber':              'object',
+'LowHouseNumber':           'object',
+'HighHouseNumber':          'object',
+'StreetName':               'object',
+'StreetCode':               'int64',
+'Zip':                     'float64',
+'Block':                     'int64',
+'Lot':                       'int64',
+'BIN':                     'float64',
+'CommunityBoard':            'int64',
+'LastRegistrationDate':     'object',
+'RegistrationEndDate':      'object'}
+
+reg_df_keep_cols = [
+    'registrationid',
+    'buildingid',
+    'boroid',
+    'boro',
+    'housenumber',
+    'lowhousenumber',
+    'highhousenumber',
+    'streetname',
+    'streetcode',
+    'zip',
+    'block',
+    'lot',
+    'bin',
+    'communityboard',
+    'lastregistrationdate',
+    'registrationenddate'
+]
+
+def main(argv):
+
+    parser = argparse.ArgumentParser(description='Import hpd registration dataset.')
+    parser = add_common_arguments(parser)
+    args = parser.parse_args()
+
+    print args
+
+    hpd_reg_dir = os.path.join(BASE_DIR, HPD_REGISTRATION_KEY)
+    mkdir_p(hpd_reg_dir)
+
+    hpd_reg_csv = os.path.join(hpd_reg_dir, "hpd_reg.csv")
+
+    if not os.path.isfile(hpd_reg_csv) or args.BUST_DISK_CACHE:
+        log.info("DL-ing HPD Registrations")
+        download_file("https://data.cityofnewyork.us/api/views/tesw-yqqr/rows.csv?accessType=DOWNLOAD", hpd_reg_csv)
+    else:
+        log.info("HPD Registrations exists, moving on...")
+
+    reg_date_time_columns = ['lastregistrationdate', 'registrationenddate']
+    reg_truncate_columns = ''
+
+    reg_description = "HPD Registrations"
+    reg_input_csv_url = hpd_reg_csv
+    reg_sep_char = ","
+    reg_pickle = os.path.join(hpd_reg_dir, 'df_reg.pkl')
+    reg_table_name = 'hpd_registrations'
+    reg_load_pickle = args.LOAD_PICKLE
+    reg_save_pickle = args.SAVE_PICKLE
+    reg_db_action = 'replace' ## if not = 'replace' then 'append'
+    reg_chunk_size = 5000
+
+    hpd_csv2sql(
+                reg_description,
+                reg_input_csv_url,
+                reg_sep_char,
+                reg_table_name,
+                reg_dtype_dict,
+                reg_load_pickle,
+                reg_save_pickle,
+                reg_pickle,
+                reg_db_action,
+                reg_truncate_columns,
+                reg_date_time_columns,
+                reg_chunk_size,
+                reg_df_keep_cols
+               )
+
+if __name__ == "__main__":
+    main(sys.argv[:1])
+
+

--- a/JPF/import-hpd-registrations.py
+++ b/JPF/import-hpd-registrations.py
@@ -26,22 +26,23 @@ HPD Registration import
 HPD_REGISTRATION_KEY = 'hpd_registration'
 
 reg_dtype_dict = {
-'RegistrationID':            'int64',
-'BuildingID':                'int64',
-'BoroID':                    'int64',
-'Boro':                     'object',
-'HouseNumber':              'object',
-'LowHouseNumber':           'object',
-'HighHouseNumber':          'object',
-'StreetName':               'object',
-'StreetCode':               'int64',
-'Zip':                     'float64',
-'Block':                     'int64',
-'Lot':                       'int64',
-'BIN':                     'float64',
-'CommunityBoard':            'int64',
-'LastRegistrationDate':     'object',
-'RegistrationEndDate':      'object'}
+    'RegistrationID':            'int64',
+    'BuildingID':                'int64',
+    'BoroID':                    'int64',
+    'Boro':                     'object',
+    'HouseNumber':              'object',
+    'LowHouseNumber':           'object',
+    'HighHouseNumber':          'object',
+    'StreetName':               'object',
+    'StreetCode':               'int64',
+    'Zip':                     'float64',
+    'Block':                     'int64',
+    'Lot':                       'int64',
+    'BIN':                     'float64',
+    'CommunityBoard':            'int64',
+    'LastRegistrationDate':     'object',
+    'RegistrationEndDate':      'object'
+}
 
 reg_df_keep_cols = [
     'registrationid',

--- a/JPF/import-pluto.py
+++ b/JPF/import-pluto.py
@@ -268,6 +268,11 @@ def main(argv):
                 PLUTO_date_format,
                )
 
+    conn = connect()
+
+    # Add some indexes
+    "create index my_idx on my_table(tstamp, user_id, type);"
+
 
 if __name__ == "__main__":
     main(sys.argv[:1])

--- a/JPF/import-pluto.py
+++ b/JPF/import-pluto.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python
+
+import os
+import os.path
+import sys
+import logging
+
+from sqlalchemy import create_engine
+
+from utils import *
+
+mkdir_p(BASE_DIR)
+
+logging.basicConfig(format='[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s',
+    datefmt='%H:%M:%S',
+    stream=sys.stdout,
+    level=logging.INFO)
+log = logging.getLogger(__name__)
+
+"""
+PLUTO IMPORT
+Manually Download PLUTO.zip from below, extract to a directory. Run below pointed at that directory.
+
+http://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyc_pluto_16v2%20.zip
+"""
+
+PLUTO_KEY = 'pluto'
+
+PLUTO_dtype_dict = {
+    'Borough':       'object',
+    'Block':       'int64',
+    'Lot':       'int64',
+    'CD':       'int64',
+    'CT2010':       'float64',
+    'CB2010':       'float64',
+    'SchoolDist':       'float64',
+    'Council':       'float64',
+    'ZipCode':       'float64',
+    'FireComp':       'object',
+    'PolicePrct':       'float64',
+    'HealthArea':       'float64',
+    'SanitBoro':       'float64',
+    'SanitDistrict':       'float64',
+    'SanitSub':       'object',
+    'Address':       'object',
+    'ZoneDist1':       'object',
+    'ZoneDist2':       'object',
+    'ZoneDist3':       'object',
+    'ZoneDist4':       'object',
+    'Overlay1':       'object',
+    'Overlay2':       'object',
+    'SPDist1':       'object',
+    'SPDist2':       'object',
+    'SPDist3':       'object',
+    'LtdHeight':       'object',
+    'SplitZone':       'object',
+    'BldgClass':       'object',
+    'LandUse':       'float64',
+    'Easements':       'int64',
+    'OwnerType':       'object',
+    'OwnerName':       'object',
+    'LotArea':       'int64',
+    'BldgArea':       'int64',
+    'ComArea':       'int64',
+    'ResArea':       'int64',
+    'OfficeArea':       'int64',
+    'RetailArea':       'int64',
+    'GarageArea':       'int64',
+    'StrgeArea':       'int64',
+    'FactryArea':       'int64',
+    'OtherArea':       'int64',
+    'AreaSource':       'int64',
+    'NumBldgs':       'int64',
+    'NumFloors':       'float64',
+    'UnitsRes':       'int64',
+    'UnitsTotal':       'int64',
+    'LotFront':       'float64',
+    'LotDepth':       'float64',
+    'BldgFront':       'float64',
+    'BldgDepth':       'float64',
+    'Ext':       'object',
+    'ProxCode':       'float64',
+    'IrrLotCode':       'object',
+    'LotType':       'float64',
+    'BsmtCode':       'float64',
+    'AssessLand':       'int64',
+    'AssessTot':       'int64',
+    'ExemptLand':       'int64',
+    'ExemptTot':       'int64',
+    'YearBuilt':       'int64',
+    'YearAlter1':       'int64',
+    'YearAlter2':       'int64',
+    'HistDist':       'object',
+    'Landmark':       'object',
+    'BuiltFAR':       'float64',
+    'ResidFAR':       'float64',
+    'CommFAR':       'float64',
+    'FacilFAR':       'float64',
+    'BoroCode':       'int64',
+    'BBL':       'int64',
+    'CondoNo':       'int64',
+    'Tract2010':       'int64',
+    'XCoord':       'float64',
+    'YCoord':       'float64',
+    'ZoneMap':       'object',
+    'ZMCode':       'object',
+    'Sanborn':       'object',
+    'TaxMap':       'float64',
+    'EDesigNum':       'object',
+    'APPBBL':       'float64',
+    'APPDate':       'object',
+    'PLUTOMapID':       'int64'
+}
+
+
+
+PLUTO_df_keep_cols = [
+    'borough',
+    'block',
+    'lot',
+    'cd',
+    'ct2010',
+    'cb2010',
+    'schooldist',
+    'council',
+    'zipcode',
+    'firecomp',
+    'policeprct',
+    'healtharea',
+    'sanitboro',
+    'sanitdistrict',
+    'sanitsub',
+    'address',
+    'zonedist1',
+    'zonedist2',
+    'zonedist3',
+    'zonedist4',
+    'overlay1',
+    'overlay2',
+    'spdist1',
+    'spdist2',
+    'spdist3',
+    'ltdheight',
+    'splitzone',
+    'bldgclass',
+    'landuse',
+    'easements',
+    'ownertype',
+    'ownername',
+    'lotarea',
+    'bldgarea',
+    'comarea',
+    'resarea',
+    'officearea',
+    'retailarea',
+    'garagearea',
+    'strgearea',
+    'factryarea',
+    'otherarea',
+    'areasource',
+    'numbldgs',
+    'numfloors',
+    'unitsres',
+    'unitstotal',
+    'lotfront',
+    'lotdepth',
+    'bldgfront',
+    'bldgdepth',
+    'ext',
+    'proxcode',
+    'irrlotcode',
+    'lottype',
+    'bsmtcode',
+    'assessland',
+    'assesstot',
+    'exemptland',
+    'exempttot',
+    'yearbuilt',
+    'yearalter1',
+    'yearalter2',
+    'histdist',
+    'landmark',
+    'builtfar',
+    'residfar',
+    'commfar',
+    'facilfar',
+    'borocode',
+    'bbl',
+    'condono',
+    'tract2010',
+    'xcoord',
+    'ycoord',
+    'zonemap',
+    'zmcode',
+    'sanborn',
+    'taxmap',
+    'edesignum',
+    'appbbl',
+    'appdate',
+    'plutomapid'
+]
+
+def main(argv):
+
+    # Connect to our database instance (config is in environment)
+    engine = connect()
+
+    pluto_dir = os.path.join(BASE_DIR, PLUTO_KEY)
+    mkdir_p(pluto_dir)
+
+    local_pluto_file = os.path.join(pluto_dir, 'pluto.csv')
+    log.info("DL-ing Pluto")
+    download_file("http://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyc_pluto_16v2%20.zip", local_pluto_file)
+
+
+    sys.stdout.write("\rUnzipping Pluto archive....")
+    unzip(local_pluto_file, pluto_dir)
+    sys.stdout.flush()
+    sys.stdout.write("\rUnzipping Pluto archive....done.\n")
+
+
+    sys.stdout.write("\rConcatenating Pluto boro csvs....")
+    pluto_csv_files_dir = os.path.join(pluto_dir, "BORO_zip_files_csv")
+    pluto_csv = os.path.join(pluto_dir, "pluto.csv")
+    pandas_concat_csv(pluto_csv_files_dir, pluto_csv)
+    sys.stdout.flush()
+    sys.stdout.write("\rConcatenating Pluto boro csvs....done.\n")
+
+    PLUTO_date_time_columns = ['appdate']
+    PLUTO_description = 'PLUTO'
+    PLUTO_input_csv_url = pluto_csv
+    PLUTO_pickle = os.path.join(pluto_dir, 'df_PLUTO_NYC.pkl')
+    PLUTO_sep_char = ","
+    PLUTO_table_name = "pluto_nyc"
+    PLUTO_load_pickle = False
+    PLUTO_save_pickle = False
+    PLUTO_db_action = "replace"
+    PLUTO_truncate_columns = []
+    PLUTO_chunk_size = 5000
+    PLUTO_max_column_size = 255
+    PLUTO_date_format = "%m/%d/%Y"
+
+    hpd_csv2sql(
+                PLUTO_description,
+                PLUTO_input_csv_url,
+                PLUTO_sep_char,
+                PLUTO_table_name,
+                PLUTO_dtype_dict,
+                PLUTO_load_pickle,
+                PLUTO_save_pickle,
+                PLUTO_pickle,
+                PLUTO_db_action,
+                PLUTO_truncate_columns,
+                PLUTO_date_time_columns,
+                PLUTO_chunk_size,
+                PLUTO_df_keep_cols,
+                PLUTO_max_column_size,
+                PLUTO_date_format,
+               )
+
+
+if __name__ == "__main__":
+    main(sys.argv)
+

--- a/JPF/utils.py
+++ b/JPF/utils.py
@@ -17,30 +17,31 @@ BASE_DIR = os.path.join(os.path.expanduser('~'), "heatseek")
 
 def add_common_arguments(parser):
 
-    parser.add_argument("--save-pickle",
-                action='store_const',
-                dest='SAVE_PICKLE',
-                const=True,
+    parser.add_argument("--load-pickle",
+                action='store_true',
+                dest='LOAD_PICKLE',
+                default=False,
                 help='Save a pickled version of the data during processing.')
 
+    parser.add_argument("--save-pickle",
+                action='store_true',
+                dest='SAVE_PICKLE',
+                default=False,
+                help='Save a pickled version of the data during processing.')
 
     parser.add_argument('--bust-disk-cache',
-                action='store_const',
+                action='store_true',
                 dest='BUST_DISK_CACHE',
-                const=False,
+                default=False,
                 help='Whether to re-download data files.')
-
-    parser.add_argument('--bust-picke-cache',
-                action='store_const',
-                dest='BUST_DISK_CACHE',
-                const=False,
-                help='Whether to re-pickle data files.')
 
     parser.add_argument('--update-or-replace-db',
                 action='store_const',
                 dest='BUST_DISK_CACHE',
                 const='replace',
                 help='Whether to update or outright replace data.')
+
+    return parser
 
 
 def mkdir_p(my_path):

--- a/JPF/utils.py
+++ b/JPF/utils.py
@@ -1,0 +1,225 @@
+import datetime
+import glob
+import os
+import sys
+import logging
+import mysql.connector
+import pandas as pd
+import pickle
+import requests
+import sqlalchemy
+import zipfile
+
+from slugify import slugify
+from sqlalchemy import create_engine
+
+BASE_DIR = os.path.join(os.path.expanduser('~'), "heatseek")
+
+def add_common_arguments(parser):
+
+    parser.add_argument("--save-pickle",
+                action='store_const',
+                dest='SAVE_PICKLE',
+                const=True,
+                help='Save a pickled version of the data during processing.')
+
+
+    parser.add_argument('--bust-disk-cache',
+                action='store_const',
+                dest='BUST_DISK_CACHE',
+                const=False,
+                help='Whether to re-download data files.')
+
+    parser.add_argument('--bust-picke-cache',
+                action='store_const',
+                dest='BUST_DISK_CACHE',
+                const=False,
+                help='Whether to re-pickle data files.')
+
+    parser.add_argument('--update-or-replace-db',
+                action='store_const',
+                dest='BUST_DISK_CACHE',
+                const='replace',
+                help='Whether to update or outright replace data.')
+
+
+def mkdir_p(my_path):
+    try:
+        os.stat(my_path)
+    except:
+        os.mkdir(my_path)
+
+
+def connect():
+
+    user = os.environ['MYSQL_USER']
+    host = os.environ['MYSQL_HOST']
+    pw = os.environ['MYSQL_PASSWORD']
+    db = os.environ['MYSQL_DATABASE']
+
+    conn_str = "mysql+mysqlconnector://{0}:{1}@{2}/{3}".format(user, pw, host, db)
+    return create_engine(conn_str, echo=False)
+
+
+def guess_sqlcol(dfparam, max_col_len):
+
+    ## GUESS AT SQL COLUMN TYPES FROM DataFrame dtypes.
+
+    dtypedict = {}
+    for i,j in zip(dfparam.columns, dfparam.dtypes):
+        if "object" in str(j):
+            dtypedict.update({i: sqlalchemy.types.NVARCHAR(length=max_col_len)}) ##big field length for HPD violations description
+
+        if "datetime" in str(j):
+            dtypedict.update({i: sqlalchemy.types.DateTime()})
+
+        if "float" in str(j):
+            dtypedict.update({i: sqlalchemy.types.Float(precision=20, asdecimal=True)}) ##big precision for LAT/LONG fields
+
+        if "int" in str(j):
+            dtypedict.update({i: sqlalchemy.types.BigInteger()})
+
+    return dtypedict
+
+
+def hpd_csv2sql(description, input_csv_url, sep_char,\
+            table_name, dtype_dict, load_pickle, save_pickle, \
+                pickle_file, db_action, truncate_columns, date_time_columns,\
+               chunk_size, keep_cols, max_col_len=255, date_format=None):
+
+    logging.basicConfig(format='[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s',
+        datefmt='%H:%M:%S',
+        stream=sys.stdout,
+        level=logging.DEBUG)
+    log = logging.getLogger(__name__)
+
+    log.info("Beginning {} Import {}".format(description,datetime.datetime.now()))
+
+    if load_pickle and os.path.isfile(pickle_file): #IF FLAGGED TO LOAD PICKLE AS TRUE
+        log.info("Flagged load of PICKLE: {} = True".format(pickle_file))
+
+        with open(pickle_file, 'r') as picklefile:
+            log.info("Begin OPEN {} Pickle: {}".format(pickle_file, datetime.datetime.now()))
+            df = pickle.load(picklefile)
+
+            # Don't just save the pickle after reading it.
+            save_pickle = False
+
+    else:
+        log.info("Reading CSV from {} .. This may take a while...".format(input_csv_url))
+
+        df = pd.read_csv(input_csv_url, sep=sep_char, dtype=dtype_dict, encoding='utf8')
+        # Pandas had a pretty serious problem with the types we expected.
+        # df = pd.read_csv(input_csv_url, encoding='utf8')
+
+        log.debug("This is what we've read in from the URL: {}".format(df.columns))
+
+        ## LET'S SEE IF THERE ARE COLUMNS TO TRUNCATE
+        ## CLEAN COLUMN NAMES
+        cols = [slugify(unicode(i.strip().replace(" ","_").replace("#","num"))) for i in df.columns]
+
+        df.columns = cols
+
+        log.debug("We've slugified, let's have another look: {}".format(df.columns))
+
+        ## KEEP ONLY THE COLUMNS OF INTEREST
+        log.info("Let's just keep the important {} columns".format(len(keep_cols)))
+        df = df[keep_cols]
+
+        ## TRIM COLUMN DATA TO MAX_LENGTH
+        log.info("... and truncate the {} known to be long".format(len(truncate_columns)))
+        for i in truncate_columns:
+            df[i] = df[i].str[:max_col_len]
+
+        ## CONVERT DATETIME COLS TO DATETIME
+        log.info("Lastly .. let's convert the {} Dates to Dates".format(len(date_time_columns)))
+        for i in date_time_columns:
+            log.info("Starting Date: {}".format(i))
+            try:
+                df[i] = pd.to_datetime(df[i],format=date_format)
+            except:
+                df[i] = pd.to_datetime('19000101')
+
+    if save_pickle:
+        log.info("Why don't we save our hard work with {} for next time".format(pickle_file))
+        with open(pickle_file, 'w') as picklefile:
+            log.info("Begin writing {} Pickle: {}".format(description,datetime.datetime.now()))
+            pickle.dump(df, picklefile)
+        log.info("Finish writing {} Pickle: {}".format(description,datetime.datetime.now()))
+
+
+    log.info("Let's now try to send it to the DB")
+    outputdict = guess_sqlcol(df, max_col_len)  #Guess at SQL columns based on DF dtypes
+    log.debug("Show us the DB column guesses\n {}".format(outputdict))
+    log.info("Begin Upload {} SQL".format(description, datetime.datetime.now()))
+    log.info("Let's see if we should replace or append our table ... {}".format(db_action))
+
+    if db_action == 'replace':
+        action = db_action
+    else:
+        action = 'append'
+
+    log.info("We're going with db_action = {}".format(action))
+    log.info("Sending our df to {}".format(table_name))
+    df.to_sql(name=table_name, con=connect(), if_exists=action,\
+              index=False, chunksize=chunk_size, dtype=outputdict)
+
+    log.info("Completed {} Import".format(description, datetime.datetime.now()))
+    log.info("Imported: {} rows".format(df.shape[0]))
+
+
+def download_file(url, local_filename):
+    # NOTE the stream=True parameter
+    r = requests.get(url, stream=True)
+    total_length = r.headers.get('content-length')
+
+    if total_length is None: # no content length header
+        f.write(response.content)
+    else:
+        dl = 0
+        total_length = int(total_length)
+        with open(local_filename, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=4096):
+                if chunk: # filter out keep-alive new chunks
+                    f.write(chunk)
+
+                    dl += len(chunk)
+                    done = int(50 * dl / total_length)
+                    sys.stdout.write("\r[%s%s]" % ('=' * done, ' ' * (50-done)) )
+                    sys.stdout.flush()
+
+    sys.stdout.write("\n")
+
+    return local_filename
+
+
+def unzip(filename, directory_to_extract_to):
+
+    zip_ref = zipfile.ZipFile(filename, 'r')
+    zip_ref.extractall(directory_to_extract_to)
+    zip_ref.close()
+
+
+def pandas_concat_csv(directory, dest_file):
+
+    allFiles = glob.glob(directory + "/*.csv") #in path provided, look for anything with a '.csv' extension and save it to this variable
+    pluto_data = pd.DataFrame()
+    pluto_list_ = []
+    for file_ in allFiles: #iterate through all csv files and create a pandas df
+        pluto_df = pd.read_csv(file_,index_col=None, header=0)
+        pluto_list_.append(pluto_df) #append every df to a big list
+    pluto_data = pd.concat(pluto_list_) #combine the big list into one big pandas df
+    pluto_data = pluto_data.reset_index(drop=True)
+    pluto_data.to_csv(dest_file, index=False)
+
+def simple_concat_csv(directory, dest_file):
+
+    #in path provided, look for anything with a '.csv' extension and save it to this variable
+    allFiles = glob.glob(directory + "/*.csv")
+    with open(dest_file, 'w') as outfile:
+        for fname in allFiles:
+            with open(fname) as infile:
+                for line in infile:
+                    outfile.write(line)
+
+

--- a/JPF/utils.py
+++ b/JPF/utils.py
@@ -110,8 +110,6 @@ def hpd_csv2sql(description, input_csv_url, sep_char,\
         log.info("Reading CSV from {} .. This may take a while...".format(input_csv_url))
 
         df = pd.read_csv(input_csv_url, sep=sep_char, dtype=dtype_dict, encoding='utf8')
-        # Pandas had a pretty serious problem with the types we expected.
-        # df = pd.read_csv(input_csv_url, encoding='utf8')
 
         log.debug("This is what we've read in from the URL: {}".format(df.columns))
 
@@ -160,10 +158,15 @@ def hpd_csv2sql(description, input_csv_url, sep_char,\
     else:
         action = 'append'
 
+    conn = connect()
+
     log.info("We're going with db_action = {}".format(action))
     log.info("Sending our df to {}".format(table_name))
-    df.to_sql(name=table_name, con=connect(), if_exists=action,\
+    df.to_sql(name=table_name, con=conn, if_exists=action,\
               index=False, chunksize=chunk_size, dtype=outputdict)
+
+    if db_action == 'replace':
+        conn.execute("ALTER TABLE %s ADD id INT PRIMARY KEY AUTO_INCREMENT;" % table_name)
 
     log.info("Completed {} Import".format(description, datetime.datetime.now()))
     log.info("Imported: {} rows".format(df.shape[0]))

--- a/JPF/utils.py
+++ b/JPF/utils.py
@@ -177,12 +177,12 @@ def download_file(url, local_filename):
     r = requests.get(url, stream=True)
     total_length = r.headers.get('content-length')
 
-    if total_length is None: # no content length header
-        f.write(response.content)
-    else:
-        dl = 0
-        total_length = int(total_length)
-        with open(local_filename, 'wb') as f:
+    with open(local_filename, 'wb') as f:
+        if total_length is None: # no content length header
+            f.write(r.content)
+        else:
+            dl = 0
+            total_length = int(total_length)
             for chunk in r.iter_content(chunk_size=4096):
                 if chunk: # filter out keep-alive new chunks
                     f.write(chunk)


### PR DESCRIPTION
Most scripts in this PR will now run within a minute or two, and will cache data files.

```bash
./import-hpd-buildings.py
./import-hpd-registration-contact.py
./import-hpd-registrations.py
./import-pluto.py

# To re-pull data files
./import-hpd-buildings.py --bust-disk-cache
./import-hpd-registration-contact.py --bust-disk-cache
./import-hpd-registrations.py --bust-disk-cache
./import-pluto.py --bust-disk-cache
```

New scripts can take advantage of helpers functions in utils.py

# Changelog

### New

* hpd buildings and registration contacts broken out. [Chris Henry]

* Import hpd registrations. [Chris Henry]

* Add primary key by default. [Chris Henry]

* Implementation of pluto imoprt as a script. [Chris Henry]

### Changes

* Add flags for using local files instead of re-downloading. [Chris Henry]

### Fix

* Handle case where download server doesn't set a content-length. [Chris Henry]