### PR TITLE
Create UDFs in MySQL container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+mysql-data/*

--- a/Dockerfile.mysql
+++ b/Dockerfile.mysql
@@ -1,0 +1,12 @@
+FROM mysql:latest
+
+RUN apt-get update && apt-get install -y wget ca-certificates build-essential libmysqlclient-dev libpcre3-dev && \
+      wget -O lib_mysqludf_preg-1.2-rc2.tar.gz https://github.com/mysqludf/lib_mysqludf_preg/archive/lib_mysqludf_preg-1.2-rc2.tar.gz && \
+      tar xzf lib_mysqludf_preg-1.2-rc2.tar.gz && \
+      cd lib_mysqludf_preg-lib_mysqludf_preg-1.2-rc2 && \
+      ./configure && \
+      make install && \
+      apt-get remove -y wget ca-certificates build-essential libmysqlclient-dev libpcre3-dev && \
+      cat installdb.sql >> /tmp/mysql-first-time.sql && \
+      cd .. && rm -rf lib_mysqludf_preg-lib_mysqludf_preg-1.2-rc2 && \
+      apt-get clean && apt-get purge

--- a/Dockerfile.mysql
+++ b/Dockerfile.mysql
@@ -7,6 +7,5 @@ RUN apt-get update && apt-get install -y wget ca-certificates build-essential li
       ./configure && \
       make install && \
       apt-get remove -y wget ca-certificates build-essential libmysqlclient-dev libpcre3-dev && \
-      cat installdb.sql >> /tmp/mysql-first-time.sql && \
       cd .. && rm -rf lib_mysqludf_preg-lib_mysqludf_preg-1.2-rc2 && \
       apt-get clean && apt-get purge

--- a/Dockerfile.mysql-udf
+++ b/Dockerfile.mysql-udf
@@ -1,0 +1,9 @@
+FROM mysql:latest
+
+RUN apt-get update && apt-get install -y wget ca-certificates && \
+    apt-get clean && apt-get purge
+
+
+COPY docker/mysql-udf.sh /root/
+
+CMD /root/mysql-udf.sh

--- a/README.md
+++ b/README.md
@@ -30,16 +30,14 @@ app.
 
 TODO: Needs better documentation.
 
-The second is to use docker;
+The second is to use docker. This method will use an .env file to configure the
+containers.
 
 * [Install Docker and docker-compose](https://docs.docker.com/engine/getstarted/)
-* Run `cp .env.example .env`
+* Run `cp .env.example .env`, and fill in any relevant values
 * Run `docker-compose up`
 * The Jupyter notebook will be running at [localhost:8888](http://localhost:8888)
 * The Rails app will be running at [localhost:3000](http://localhost:3000)
-
-This method will use an .env file to configure the containers.
-
 
 To get into the web container, and run rake tasks, etc;
 
@@ -60,3 +58,16 @@ on why you need to use `127.0.0.1`.
 ```bash
 mysql -h 127.0.0.1 -P 3306 -u deltanyc -ppassword deltanyc
 ```
+
+A note on preg UDFs
+***************************
+The cleanup utils make extensive use of [User Defined preg functions](https://github.com/mysqludf/lib_mysqludf_preg).
+These aren't available in the general MySQL docker container, and the container
+provided by the [uqlibrary](https://github.com/uqlibrary/docker-mysql-udf-preg)
+hasn't been built in a while, so it doesn't have recent fixes to the upstream
+MySQL container.
+
+One challenge here is that the `CREATE FUNCTION` statements need to be called by
+a client, as MySQL UDFs are registered in the `mysql` database. This was solved
+by creating a quick utility container (`db-udf`) that will come up with
+docker-compose, pull the relevant `CREATE` commands, run them, and exit.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,9 @@ Getting Started
 
 There are two options for getting started with this repo.
 
-The first is to install the Python packages and run Jupyter. Ditto for the rails
-app.
-
-TODO: Needs better documentation.
+The first is to install MySQL, and Python packages listed in requirements.txt.
+Ditto for the rails app. Additionally, MySQL requires additional
+[PRCE UDFs](https://github.com/mysqludf/lib_mysqludf_preg).
 
 The second is to use docker. This method will use an .env file to configure the
 containers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '2'
 services:
   db:
-    image: mysql:latest
+    build:
+      dockerfile: Dockerfile.mysql
+      context: .
     env_file: .env
     volumes:
       - ./mysql-data/:/var/lib/mysql/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,15 @@ services:
       - ./mysql-data/:/var/lib/mysql/
     ports:
       - "3306:3306"
+  db-udf:
+    build:
+      dockerfile: Dockerfile.mysql-udf
+      context: .
+    environment:
+      MYSQL_HOST: db
+    env_file: .env
+    depends_on:
+      - db
   web:
     build:
       context: ./angular-rails-app/

--- a/docker/mysql-udf.sh
+++ b/docker/mysql-udf.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+FILE=/root/installdb.sql
+
+wget https://raw.githubusercontent.com/mysqludf/lib_mysqludf_preg/testing/installdb.sql -O $FILE
+sed -i 's/USE mysql;//g' $FILE
+
+MYSQL_CMD="mysql -h $MYSQL_HOST -u root -p$MYSQL_ROOT_PASSWORD"
+
+echo $MYSQL_CMD
+
+until $MYSQL_CMD -e ";"; do
+  >&2 echo "MySQL is unavailable - sleeping"
+  sleep 1
+done
+
+echo "MySQL is available..."
+
+$MYSQL_CMD deltanyc < $FILE
+
+echo "UDFs added successfully"


### PR DESCRIPTION
A few notes;

* The container provided at [Dockerhub](https://hub.docker.com/r/uqlibrary/docker-mysql-udf-preg/) hasn't been built for over a year. This means the Docker image available was built using a very old upstream container, hence most of the problems we're seeing. 
* This PR automates the process of installing the required binaries into the db container, and bringing up a quick helper container (`db-udf`) to run the necessary `CREATE FUNCTION` commands on start of docker-compose.

# Changelog

### New

* Update README with preg install notes. [Chris Henry]

* Create a helper container that will run the CREATE FUNCTION cmds for the preg* functions. [Chris Henry]

* Create new docker file for installing preg udfs. [Chris Henry]


