### PR TITLE
data-imports only requirements.txt

### DIFF
--- a/data-imports/requirements.txt
+++ b/data-imports/requirements.txt
@@ -1,0 +1,12 @@
+MySQL-python==1.2.5
+SQLAlchemy==1.1.4
+mysql-connector==2.1.4
+numpy==1.11.3
+pandas==0.19.2
+python-dateutil==2.6.0
+pytz==2016.10
+requests==2.12.4
+six==1.10.0
+slugify==0.0.1
+wget==3.2
+wsgiref==0.1.2


### PR DESCRIPTION
I was running into errors spinning up a new virtualenv from the root requirements.txt, so I installed only the stuff I seemed to need for data-imports and pip freeze-d it into a new requirements.txt. This stuff should be sufficient for running these scripts.