### PR TITLE
Various fixes

### DIFF
--- a/data-imports/clean_utils.py
+++ b/data-imports/clean_utils.py
@@ -8,9 +8,9 @@ def clean_addresses(table, column):
     #    UPDATE {table} SET {column} = array_to_string(regexp_matches('(.*)(\d+)(?:TH|RD|ND|ST)( .+)'), '', {column} ) WHERE {column} ~ '.*(\d+)(?:TH|RD|ND|ST)( .+).*';
     # No idea where regexp_matches is defined? Looks like it's a Postgresql command?
     return '''
+    UPDATE {table} SET {column} = preg_replace( '/\\\./', '', {column} );
     UPDATE {table} SET {column} = preg_replace( '/, MANHATTAN|, BROOKLYN|, STATEN ISLAND|, QUEENS|, BRONX/i', '', {column} );
     UPDATE {table} SET {column} = preg_replace( '/ AVE$|-AVE$| -AVE$/', ' AVENUE', {column} );
-    UPDATE {table} SET {column} = preg_replace( '/\./', '', {column} );
     UPDATE {table} SET {column} = preg_replace( '/ LA$/', ' LANE', {column} );
     UPDATE {table} SET {column} = preg_replace( '/ LN$/', ' LANE', {column} );
     UPDATE {table} SET {column} = preg_replace( '/ PL$/', ' PLACE', {column} );

--- a/data-imports/import-hpd-registration-contact.py
+++ b/data-imports/import-hpd-registration-contact.py
@@ -12,7 +12,7 @@ mkdir_p(BASE_DIR)
 logging.basicConfig(format='[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s',
     datefmt='%H:%M:%S',
     stream=sys.stdout,
-    level=logging.INFO)
+    level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
 """
@@ -46,8 +46,8 @@ truncate_columns = []
 date_time_columns = []
 
 keep_cols = [
-    'Registrationcontactid',
-    'Registrationid',
+    'RegistrationContactID',
+    'RegistrationID',
     'Type',
     'ContactDescription',
     'CorporationName',


### PR DESCRIPTION
# Changelog

### Fixes

* Apparently the dot needs three slashes to be properly escaped. [Chris Henry]

* Column names for keep_cols need to be same case. [Chris Henry]

This PR fixes https://github.com/chrishenry/deltanyc-heatseek/issues/64. Re-running both `./import-hpd-registration-contact.py` and `rake db_connector:owners` should resolve data issues.

I've also resolved https://github.com/chrishenry/deltanyc-heatseek/issues/60. Since the `clean_addresses` function would wipe street addresses for all columns, we'll need to re-run for all data imports.