### PR TITLE
Load Property and Owner data before state change

### DIFF
--- a/angular-rails-app/app/assets/javascripts/app.js
+++ b/angular-rails-app/app/assets/javascripts/app.js
@@ -19,17 +19,22 @@ angular
         .state('owner', {
           url: '/owners/:id',
           templateUrl: 'owner/owner.html',
-          controller: 'OwnerController as vm'
+          controller: 'OwnerController as vm',
+          resolve: {
+            owner: function (OwnerService, $stateParams) {
+            return OwnerService.getOwner($stateParams.id);
+          }
+         }
         })
         .state('property', {
           url: '/properties/:id',
           templateUrl: 'property/property.html',
           controller: 'PropertyController as vm',
           resolve: {
-          property: function (PropertyService, $stateParams) {
+            property: function (PropertyService, $stateParams) {
             return PropertyService.getProperty($stateParams.id);
           }
-        }
+         }
         });
 
 

--- a/angular-rails-app/app/assets/javascripts/app.js
+++ b/angular-rails-app/app/assets/javascripts/app.js
@@ -24,7 +24,12 @@ angular
         .state('property', {
           url: '/properties/:id',
           templateUrl: 'property/property.html',
-          controller: 'PropertyController as vm'
+          controller: 'PropertyController as vm',
+          resolve: {
+          property: function (PropertyService, $stateParams) {
+            return PropertyService.getProperty($stateParams.id);
+          }
+        }
         });
 
 

--- a/angular-rails-app/app/assets/javascripts/owner/owner.controller.js
+++ b/angular-rails-app/app/assets/javascripts/owner/owner.controller.js
@@ -2,10 +2,10 @@ angular
   .module('app')
   .controller('OwnerController', OwnerController);
 
-OwnerController.$inject = ['OwnerService', '$stateParams', '$state', 'owner'];
+OwnerController.$inject = ['OwnerService', 'owner'];
 
 
-function OwnerController(OwnerService, $stateParams, $state, owner) {
+function OwnerController(OwnerService, owner) {
   var vm = this;  
   vm.data = owner.data;
 }

--- a/angular-rails-app/app/assets/javascripts/owner/owner.controller.js
+++ b/angular-rails-app/app/assets/javascripts/owner/owner.controller.js
@@ -2,22 +2,10 @@ angular
   .module('app')
   .controller('OwnerController', OwnerController);
 
-OwnerController.$inject = ['OwnerService', '$stateParams', '$state'];
+OwnerController.$inject = ['OwnerService', '$stateParams', '$state', 'owner'];
 
 
-function OwnerController(OwnerService, $stateParams, $state) {
-  var vm = this
-  
-
-  vm.getOwner = function(){
-    OwnerService.getOwner($stateParams.id)
-    .then(function(owner){
-      vm.data = owner.data;
-    }, function(error){
-        alert('Unable to get owner data: ' + error.statusText);
-    })
-  }
-
-  vm.getOwner();  
-
+function OwnerController(OwnerService, $stateParams, $state, owner) {
+  var vm = this;  
+  vm.data = owner.data;
 }

--- a/angular-rails-app/app/assets/javascripts/property/property.controller.js
+++ b/angular-rails-app/app/assets/javascripts/property/property.controller.js
@@ -2,10 +2,10 @@ angular
   .module('app')
   .controller('PropertyController', PropertyController);
 
-PropertyController.$inject = ['PropertyService', '$stateParams', '$state', 'property'];
+PropertyController.$inject = ['PropertyService','property'];
 
 
-function PropertyController(PropertyService, $stateParams, $state, property) {
+function PropertyController(PropertyService, property) {
   var vm = this;  
   vm.data = property.data;
 }

--- a/angular-rails-app/app/assets/javascripts/property/property.controller.js
+++ b/angular-rails-app/app/assets/javascripts/property/property.controller.js
@@ -6,10 +6,7 @@ PropertyController.$inject = ['PropertyService', '$stateParams', '$state', 'prop
 
 
 function PropertyController(PropertyService, $stateParams, $state, property) {
-  var vm = this;
-  
+  var vm = this;  
   vm.data = property.data;
- 
-
 }
 

--- a/angular-rails-app/app/assets/javascripts/property/property.controller.js
+++ b/angular-rails-app/app/assets/javascripts/property/property.controller.js
@@ -2,23 +2,14 @@ angular
   .module('app')
   .controller('PropertyController', PropertyController);
 
-PropertyController.$inject = ['PropertyService', '$stateParams', '$state'];
+PropertyController.$inject = ['PropertyService', '$stateParams', '$state', 'property'];
 
 
-function PropertyController(PropertyService, $stateParams, $state) {
-  var vm = this
+function PropertyController(PropertyService, $stateParams, $state, property) {
+  var vm = this;
   
-
-  vm.getProperty = function(){
-    PropertyService.getProperty($stateParams.id)
-    .then(function(property){
-      vm.data = property.data;
-    }, function(error){
-        alert('Unable to get property data: ' + error.statusText);
-    })
-  }
-
-  vm.getProperty();  
+  vm.data = property.data;
+ 
 
 }
 

--- a/angular-rails-app/app/assets/stylesheets/custom.css
+++ b/angular-rails-app/app/assets/stylesheets/custom.css
@@ -71,8 +71,9 @@ button.btn.btn-secondary {
   background-color: black;
   color: white;
   margin-bottom: 10px;
-  width: 50px;
+  width: 58px;
 }
+
 
 div#instructions {
   padding-top: 18px;


### PR DESCRIPTION
Closes #41 

## Changes ##

- Add a `resove` block in `app.js` to fetch data from PropertyService and OwnerService, before the state change and page load.  This way, the user will not have to wait for data after the page renders.  The data will already be there.  This, in combination with the new addition of the spinner on the home page, should solve the issue. 

