### PR TITLE
Pagination of Property details

### DIFF
--- a/angular-rails-app/app/assets/javascripts/app.js
+++ b/angular-rails-app/app/assets/javascripts/app.js
@@ -1,5 +1,6 @@
 angular
-    .module('app', ['ui.router', 'templates', 'google.places', 'angularSlideables', 'ui.bootstrap', 'angularSpinners'])
+    .module('app', ['ui.router', 'templates', 'google.places', 'angularSlideables', 
+      'ui.bootstrap', 'angularSpinners', 'angularUtils.directives.dirPagination'])
     .config(function ($stateProvider, $urlRouterProvider) {
 
       $stateProvider

--- a/angular-rails-app/app/assets/javascripts/application.js
+++ b/angular-rails-app/app/assets/javascripts/application.js
@@ -20,5 +20,5 @@
 //= require angular-google-places-autocomplete
 //= require AngularSlideables/angularSlideables
 //= require angular-spinners
-//= require dirPagination
+//= require angular-utils-pagination
 //= require_tree .

--- a/angular-rails-app/app/assets/javascripts/application.js
+++ b/angular-rails-app/app/assets/javascripts/application.js
@@ -20,4 +20,5 @@
 //= require angular-google-places-autocomplete
 //= require AngularSlideables/angularSlideables
 //= require angular-spinners
+//= require dirPagination
 //= require_tree .

--- a/angular-rails-app/app/assets/javascripts/property/property.html
+++ b/angular-rails-app/app/assets/javascripts/property/property.html
@@ -348,13 +348,20 @@
                 <th>Status</th>
                 <th>Judgement</th>
               </tr>
-              <tr ng-repeat="l in vm.data.litigations">
+              <tr dir-paginate="l in vm.data.litigations | itemsPerPage:4">
                 <td>{{ l.case_open_date }}</td>
                 <td>{{ l.case_type }}</td>
                 <td>{{ l.case_status }}</td>
                 <td>{{ l.case_judgement }}</td>
               </tr>
             </table>
+              <div class="text-center">
+                <dir-pagination-controls
+                max-size="4"
+                direction-links="true"
+                boundary-links="true" >
+              </dir-pagination-controls>
+            </div>
           </div>
 
         </div>

--- a/angular-rails-app/app/assets/javascripts/property/property.html
+++ b/angular-rails-app/app/assets/javascripts/property/property.html
@@ -120,7 +120,7 @@
                 <th>Status Date</th>
                 <th>Certified Date</th>
               </tr>
-              <tr ng-repeat="v in vm.data.hpd_violations">
+              <tr dir-paginate="v in vm.data.hpd_violations | itemsPerPage:10" pagination-id="hpd_violations">
                 <td>{{ v.inspection_date }}</td>
                 <td>{{ v.violation_class }}</td>
                 <td>{{ v.order_number }}</td>
@@ -131,6 +131,14 @@
                 <td>{{ v.certified_date }}</td>
               </tr>
             </table>
+            <div class="text-center">
+                <dir-pagination-controls
+                pagination-id="hpd_violations"
+                max-size="4"
+                direction-links="true"
+                boundary-links="true" >
+              </dir-pagination-controls>
+            </div>
           </div>
 
         </div>
@@ -175,7 +183,7 @@
                 <th>Status ID</th>
                 <th>Status Date</th>
               </tr>
-              <tr ng-repeat="c in vm.data.hpd_complaints">
+              <tr dir-paginate="c in vm.data.hpd_complaints | itemsPerPage:10" pagination-id="hpd_complaints">
                 <td>{{ c.received_date }}</td>
                 <td>{{ c.code_id }}</td>
                 <td>{{ c.apartment }}</td>
@@ -187,6 +195,14 @@
                 <td>{{ c.status_date }}</td>
               </tr>
             </table>
+            <div class="text-center">
+                <dir-pagination-controls
+                pagination-id="hpd_complaints"
+                max-size="4"
+                direction-links="true"
+                boundary-links="true" >
+              </dir-pagination-controls>
+            </div>
           </div>
         </div>
       </div>
@@ -241,7 +257,7 @@
                 <th>Building<br>Type</th>
                 <th>Work<br>Type</th>
               </tr>
-              <tr ng-repeat="d in vm.data.dob_permits">
+              <tr dir-paginate="d in vm.data.dob_permits | itemsPerPage:10" pagination-id="dob_permits">
                 <td>{{ d.job_num }}</td>
                 <td>{{ d.job_type }}</td>
                 <td>{{ d.job_start_date }}</td>
@@ -254,6 +270,14 @@
                 <td>{{ d.work_type }}</td>
               </tr>
             </table>
+            <div class="text-center">
+                <dir-pagination-controls
+                pagination-id="dob_permits"
+                max-size="4"
+                direction-links="true"
+                boundary-links="true" >
+              </dir-pagination-controls>
+            </div>
           </div>
 
         </div>
@@ -290,7 +314,7 @@
                 <th>Disposition Date</th>
                 <th>Disposition Comments</th>
               </tr>
-              <tr ng-repeat="v in vm.data.dob_violations">
+              <tr dir-paginate="v in vm.data.dob_violations | itemsPerPage:10" pagination-id="dob_violations">
                 <td>{{ v.issue_date }}</td>
                 <td>{{ v.violation_type }}</td>
                 <td>{{ v.violation_category }}</td>
@@ -298,6 +322,14 @@
                 <td>{{ v.disposition_comments }}</td>
               </tr>
             </table>
+            <div class="text-center">
+                <dir-pagination-controls
+                pagination-id="dob_violations"
+                max-size="4"
+                direction-links="true"
+                boundary-links="true" >
+              </dir-pagination-controls>
+            </div>
           </div>
 
         </div>
@@ -348,7 +380,7 @@
                 <th>Status</th>
                 <th>Judgement</th>
               </tr>
-              <tr dir-paginate="l in vm.data.litigations | itemsPerPage:4" pagination-id="litigations">
+              <tr dir-paginate="l in vm.data.litigations | itemsPerPage:10" pagination-id="litigations">
                 <td>{{ l.case_open_date }}</td>
                 <td>{{ l.case_type }}</td>
                 <td>{{ l.case_status }}</td>
@@ -413,7 +445,7 @@
                 <th>Closed Date</th>
                 <th>Resoutions Description</th>
               </tr>
-              <tr ng-repeat="c in vm.data.complaint311s">
+              <tr dir-paginate="c in vm.data.complaint311s | itemsPerPage:10" pagination-id="complaints311">
                 <td>{{ c.created_date }}</td>
                 <td>{{ c.complaint_type }}</td>
                 <td>{{ c.status }}</td>
@@ -423,6 +455,14 @@
                 <td>{{ c.resolution_description }}</td>
               </tr>
             </table>
+            <div class="text-center">
+                <dir-pagination-controls
+                pagination-id="complaints311"
+                max-size="4"
+                direction-links="true"
+                boundary-links="true" >
+              </dir-pagination-controls>
+            </div>
           </div>
 
         </div>

--- a/angular-rails-app/app/assets/javascripts/property/property.html
+++ b/angular-rails-app/app/assets/javascripts/property/property.html
@@ -348,7 +348,7 @@
                 <th>Status</th>
                 <th>Judgement</th>
               </tr>
-              <tr dir-paginate="l in vm.data.litigations | itemsPerPage:4">
+              <tr dir-paginate="l in vm.data.litigations | itemsPerPage:4" pagination-id="litigations">
                 <td>{{ l.case_open_date }}</td>
                 <td>{{ l.case_type }}</td>
                 <td>{{ l.case_status }}</td>
@@ -357,6 +357,7 @@
             </table>
               <div class="text-center">
                 <dir-pagination-controls
+                pagination-id="litigations"
                 max-size="4"
                 direction-links="true"
                 boundary-links="true" >

--- a/angular-rails-app/app/serializers/property_serializer.rb
+++ b/angular-rails-app/app/serializers/property_serializer.rb
@@ -33,23 +33,23 @@ class PropertySerializer < ActiveModel::Serializer
   end
 
   has_many :litigations do
-    @object.litigations.limit(5)
+    @object.litigations.limit(30)
   end
 
   has_many :dob_violations do
-    @object.dob_violations.limit(5)
+    @object.dob_violations.limit(30)
   end
 
   has_many :dob_permits do
-    @object.dob_permits.limit(5)
+    @object.dob_permits.limit(30)
   end
 
   has_many :complaint311s do
-    @object.complaint311s.limit(5)
+    @object.complaint311s.limit(30)
   end
 
   has_many :hpd_complaints do
-    @object.hpd_complaints.where(status: 'OPEN').limit(5)
+    @object.hpd_complaints.where(status: 'OPEN').limit(30)
   end
 
 end

--- a/angular-rails-app/bower.json
+++ b/angular-rails-app/bower.json
@@ -8,7 +8,8 @@
       "AngularSlideables": "*",
       "angular-google-places-autocomplete": "0.2.x",
       "angular-mocks": "1.5.x",
-      "angular-spinners": "3.1.x"
+      "angular-spinners": "3.1.x",
+      "angular-utils-pagination": "0.11.x"
     }
   }
 }


### PR DESCRIPTION
References Issue #42 

## Changes ##

- Implemented [angularUtils](https://github.com/michaelbromley/angularUtils/tree/master/src/directives/pagination#working-with-asynchronous-data) pagination directive, to paginate details tables (litigations, 311 data, etc) on a Property's show page, on the front end.  

## Notes/Questions ##

While it is possible to use this directive with asynchronous data (rather than loading all data into the front end, and then paginating from there), I am not sure how to paginate **associated objects**  through a has_many relationship  on the back end.   For now, I have simply increased the limit on the has_many relationships in the `PropertySerializer`.   This 50% solves issue #42, but I'm still not certain how to handle the back end.  

I'm wondering if a solution would be to overhaul / restructure the serializers altogether so there is no nesting, but each association has it's own endpoint....  Then to render a show page for a Property, it would require calls to all of the individual endpoints, filtered by property_id.  An endpoint would then get called with a property_id parameter and a page parameter, I guess.    

If anyone has input / thoughts / suggestions, let me know.