### PR TITLE
Add BBL column to dob_permits

### DIFF
--- a/data-imports/import-dob-permits.py
+++ b/data-imports/import-dob-permits.py
@@ -159,7 +159,9 @@ def sql_cleanup(args):
     log.info('SQL cleanup...')
 
     sql = clean_addresses(table_name, "street_name") + \
-        clean_boro(table_name, "borough", full_name_boro_replacements())
+        clean_boro(table_name, "borough", full_name_boro_replacements()) + \
+        add_boroid(table_name, "borough") + \
+        clean_bbl(table_name, "boroughid", "block", "lot")
 
     run_sql(sql, args.TEST_MODE)
 


### PR DESCRIPTION
dob_permits had a boro name column we cleaned to a 2-letter code, but no numerical ID column. The new code adds this column, populates it from the code using a lookup table, then runs the existing BBL creation code.