### PR TITLE
Fix zip columns

### DIFF
--- a/data-imports/import_hpd_complaints.py
+++ b/data-imports/import_hpd_complaints.py
@@ -30,7 +30,7 @@ dtype_dict = {
     'Borough':            'object',
     'HouseNumber':        'object',
     'StreetName':         'object',
-    'Zip':               'float64',
+    'Zip':               'object',
     'Block':               'int64',
     'Lot':                 'int64',
     'Apartment':          'object',

--- a/data-imports/import_hpd_litigations.py
+++ b/data-imports/import_hpd_litigations.py
@@ -30,7 +30,7 @@ dtype_dict = {
     'Boro':              'object',
     'HouseNumber':       'object',
     'StreetName':        'object',
-    'Zip':              'float64',
+    'Zip':              'object',
     'Block':              'int64',
     'Lot':                'int64',
     'CaseType':          'object',

--- a/data-imports/import_hpd_open_violations.py
+++ b/data-imports/import_hpd_open_violations.py
@@ -39,7 +39,7 @@ dtype_dict = {
     'HighHouseNumber':           'object',
     'StreetName':                'object',
     'StreetCode':                 'int64',
-    'Zip':                      'float64',
+    'Zip':                      'object',
     'Apartment':                 'object',
     'Story':                     'object',
     'Block':                      'int64',

--- a/data-imports/import_hpd_registrations.py
+++ b/data-imports/import_hpd_registrations.py
@@ -33,7 +33,7 @@ dtype_dict = {
     'HighHouseNumber':          'object',
     'StreetName':               'object',
     'StreetCode':               'int64',
-    'Zip':                     'float64',
+    'Zip':                      'object',
     'Block':                     'int64',
     'Lot':                       'int64',
     'BIN':                     'float64',


### PR DESCRIPTION
Storing Zip codes as ints instead of strings will drop leading 0s, and will also mess up zips reported in #####-#### format.
Also, storing as strings uses less memory than bigint for plain 5-digit zips.